### PR TITLE
Auto-toggle logging target based on env vars.

### DIFF
--- a/crates/rslint_scope/generated/differential_datalog/src/program/worker.rs
+++ b/crates/rslint_scope/generated/differential_datalog/src/program/worker.rs
@@ -138,8 +138,17 @@ impl<'a> DDlogWorker<'a> {
 
     pub fn run(mut self) -> Result<(), String> {
         if let Err(_) = ::std::env::var("TIMELY_WORKER_LOG_ADDR") {
-            // Initialize profiling
-            self.init_profiling();
+            if let Ok(block_profiling) = ::std::env::var("BLOCK_DIFFERENTIAL_DATAFLOW_PROFILING") {
+                match block_profiling.as_str() {
+                    "0" | "false" | "FALSE" | "no" | "NO" =>
+                        // Initialize profiling
+                        self.init_profiling(),
+                    _ => ()
+                }
+            } else {
+                // Initialize profiling
+                self.init_profiling();
+            }
         }
 
         if let Ok(addr) = ::std::env::var("DIFFERENTIAL_LOG_ADDR") {


### PR DESCRIPTION
Disable internal profiling if `TIMELT_WORKER_ADDR` is set.
Activate differential_dataflow logging if `DIFFERENTIAL_LOG_ADDR` is set.